### PR TITLE
Improve desktop mirroring

### DIFF
--- a/core/java/android/hardware/display/DisplayManager.java
+++ b/core/java/android/hardware/display/DisplayManager.java
@@ -366,8 +366,8 @@ public final class DisplayManager {
      *
      * @hide
      */
-    public void enableHdmiMirroring() {
-        mGlobal.enableHdmiMirroring();
+    public void enablePhoneMirroring() {
+        mGlobal.enablePhoneMirroring();
     }
 
     /**
@@ -375,8 +375,8 @@ public final class DisplayManager {
      *
      * @hide
      */
-    public void disableHdmiMirroring() {
-        mGlobal.disableHdmiMirroring();
+    public void disablePhoneMirroring() {
+        mGlobal.disablePhoneMirroring();
     }
 
     /**
@@ -384,8 +384,8 @@ public final class DisplayManager {
      *
      * @hide
      */
-    public boolean isHdmiMirroringEnabled() {
-        return mGlobal.isHdmiMirroringEnabled();
+    public boolean isPhoneMirroringEnabled() {
+        return mGlobal.isPhoneMirroringEnabled();
     }
 
     /**

--- a/core/java/android/hardware/display/DisplayManagerGlobal.java
+++ b/core/java/android/hardware/display/DisplayManagerGlobal.java
@@ -19,7 +19,6 @@
 package android.hardware.display;
 
 import android.content.Context;
-import android.content.res.Configuration;
 import android.hardware.display.DisplayManager.DisplayListener;
 import android.media.projection.MediaProjection;
 import android.media.projection.IMediaProjection;
@@ -262,25 +261,25 @@ public final class DisplayManagerGlobal {
         }
     }
 
-    public void enableHdmiMirroring() {
+    public void enablePhoneMirroring() {
         try {
-            mDm.enableHdmiMirroring();
+            mDm.enablePhoneMirroring();
         } catch (RemoteException ex) {
             Log.e(TAG, "Failed to enable mirroring with display manager service.", ex);
         }
     }
 
-    public void disableHdmiMirroring() {
+    public void disablePhoneMirroring() {
         try {
-            mDm.disableHdmiMirroring();
+            mDm.disablePhoneMirroring();
         } catch (RemoteException ex) {
             Log.e(TAG, "Failed to disable mirroring with display manager service.", ex);
         }
     }
 
-    public boolean isHdmiMirroringEnabled() {
+    public boolean isPhoneMirroringEnabled() {
         try {
-            return mDm.isHdmiMirroringEnabled();
+            return mDm.isPhoneMirroringEnabled();
         } catch (RemoteException ex) {
             Log.e(TAG, "Failed to get mirroring configuration from display manager service.", ex);
         }

--- a/core/java/android/hardware/display/IDisplayManager.aidl
+++ b/core/java/android/hardware/display/IDisplayManager.aidl
@@ -85,7 +85,7 @@ interface IDisplayManager {
      *
      * Mirroring support
      */
-     void enableHdmiMirroring();
-     void disableHdmiMirroring();
-     boolean isHdmiMirroringEnabled();
+     void enablePhoneMirroring();
+     void disablePhoneMirroring();
+     boolean isPhoneMirroringEnabled();
 }

--- a/core/java/android/view/Display.java
+++ b/core/java/android/view/Display.java
@@ -96,12 +96,10 @@ public final class Display {
     public static final int DEFAULT_DISPLAY = 0;
 
     /**
-     * maru
-     *
-     * Fixed display id for the default external display. Currently only HDMI.
+     * The default Display id for the desktop, which is the id of Maru Desktop's "virtual" display.
      * @hide
      */
-    public static final int DEFAULT_EXTERNAL_DISPLAY = 1;
+    public static final int DEFAULT_DESKTOP_DISPLAY = 1;
 
     /**
      * Invalid display id.

--- a/packages/SystemUI/res/values/strings.xml
+++ b/packages/SystemUI/res/values/strings.xml
@@ -1141,12 +1141,12 @@
     <!-- Maru -->
 
     <!-- QuickSettings: MMirror [CHAR LIMIT=NONE] -->
-    <string name="quick_settings_mirroring_mode_label">Mirror screen</string>
+    <string name="quick_settings_mirroring_mode_label">Mirror phone</string>
 
     <!-- Announcement made when mirroring changes to disabled (not shown on the screen). [CHAR LIMIT=NONE] -->
-    <string name="accessibility_qs_mirroring_changed_off">Screen mirroring turned off.</string>
+    <string name="accessibility_qs_mirroring_changed_off">Phone mirroring turned off.</string>
     <!-- Announcement made when mirroring changes to enabled (not shown on the screen). [CHAR LIMIT=NONE] -->
-    <string name="accessibility_qs_mirroring_changed_on">Screen mirroring turned on.</string>
+    <string name="accessibility_qs_mirroring_changed_on">Phone mirroring turned on.</string>
 
     <!-- QuickSettings: MDesktop [CHAR LIMIT=NONE] -->
     <string name="quick_settings_mdesktop_mode_label">Desktop</string>

--- a/services/core/java/com/android/server/display/LogicalDisplay.java
+++ b/services/core/java/com/android/server/display/LogicalDisplay.java
@@ -275,11 +275,14 @@ final class LogicalDisplay {
      *
      * @param device The display device to modify.
      * @param isBlanked True if the device is being blanked.
+     * @param layerStackOverride The layerstack to associate the device with, or
+     *                           < 0 to use the primary display device's layerstack
      */
     public void configureDisplayInTransactionLocked(DisplayDevice device,
-            boolean isBlanked) {
+            boolean isBlanked, int layerStackOverride) {
         // Set the layer stack.
-        device.setLayerStackInTransactionLocked(isBlanked ? BLANK_LAYER_STACK : mLayerStack);
+        int layerStack = layerStackOverride < 0 ? mLayerStack : layerStackOverride;
+        device.setLayerStackInTransactionLocked(isBlanked ? BLANK_LAYER_STACK : layerStack);
 
         // Set the color transform and mode.
         if (device == mPrimaryDisplayDevice) {
@@ -350,6 +353,17 @@ final class LogicalDisplay {
         mTempDisplayRect.top += mDisplayOffsetY;
         mTempDisplayRect.bottom += mDisplayOffsetY;
         device.setProjectionInTransactionLocked(orientation, mTempLayerStackRect, mTempDisplayRect);
+    }
+
+    /**
+     * Stock method signature that uses the associated physical display's layer stack as usual.
+     *
+     * @param device
+     * @param isBlanked
+     */
+    public void configureDisplayInTransactionLocked(DisplayDevice device,
+            boolean isBlanked) {
+        configureDisplayInTransactionLocked(device, isBlanked, -1);
     }
 
     /**


### PR DESCRIPTION
Instead of attaching Display.DEFAULT_EXTERNAL_DISPLAY to only an HDMI
LocalDisplay, we reserve Display.DEFAULT_DESKTOP_DISPLAY (id=2) for a
"virtual" Maru Desktop display that we assume exists at all times, much
like Display.DEFAULT_DISPLAY is reserved for the built-in phone screen.

When a display device is selected for mirroring, we check whether phone
mirroring is enabled or not and mirror either the phone LogicalDisplay
via the usual path, or mirror the desktop by by overriding the display
device's associated LogicalDisplay's layerstack to be
Display.DEFAULT_DESKTOP_DISPLAY.

Note that this affects ALL displays that are eligible for mirroring,
including Chromecast devices!

This also involves some refactoring:

Refactor the HdmiMirroring* APIs to PhoneMirroring for clarity in
the wake of the new mirroring behavior.

Also update MMirrorTile to track presentation displays instead of just
HDMI displays now. The "Mirror phone" QS tile will show up if any
public presentation display is available on the system.

Final testing with both desktop and phone mirroring:

- Normal HDMI display flow works
- Chromecast display flow works
- Both HDMI and Chromecast work concurrently
- Both HDMI and Chromecast desktop mirroring, plus simultaneous
YouTube video casting work

Signed-off-by: Preetam D'Souza <preetamjdsouza@gmail.com>